### PR TITLE
Rotate offering-card icons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -457,11 +457,12 @@ header {
   height: auto;
   margin-bottom: 1rem;
   filter: brightness(0.9);
+  transform: rotate(-90deg);
+  transition: transform 0.3s ease;
 }
 
 .offering-card:hover .offering-icon {
-  transform: scale(1.05);
-  transition: transform 0.3s ease;
+  transform: rotate(-90deg) scale(1.05);
 }
 
 .offering-card h4 {


### PR DESCRIPTION
## Summary
- Rotate offering-card icons by -90 degrees and keep rotation during hover scale

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c6c23a650832abf73ce6c37c3745d