### PR TITLE
Add ARIA attributes and keyboard controls to accordion

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,17 +4,41 @@ import logo from './assets/images/eixo-logo-white.png';
 import icon from './assets/images/eixo-icon-white.png';
 import { content, offerings } from './content';
 
-const AccordionItem = ({ title, content, isOpen, onClick }) => (
-  <div className={`accordion-item ${isOpen ? 'open' : ''}`}>
-    <button className="accordion-title" onClick={onClick}>
-      <span>{title}</span>
-      <span className="accordion-icon">{isOpen ? '−' : '+'}</span>
-    </button>
-    <div className={`accordion-content ${isOpen ? 'visible' : 'hidden'}`}>
-      <p>{content}</p>
+const AccordionItem = ({ id, title, content, isOpen, onClick }) => {
+  const buttonId = `accordion-header-${id}`;
+  const panelId = `accordion-panel-${id}`;
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
+  return (
+    <div className={`accordion-item ${isOpen ? 'open' : ''}`}>
+      <button
+        id={buttonId}
+        className="accordion-title"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        type="button"
+      >
+        <span>{title}</span>
+        <span className="accordion-icon">{isOpen ? '−' : '+'}</span>
+      </button>
+      <div
+        id={panelId}
+        className={`accordion-content ${isOpen ? 'visible' : 'hidden'}`}
+        role="region"
+        aria-labelledby={buttonId}
+      >
+        <p>{content}</p>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 function App() {
   const [lang, setLang] = useState('en');
@@ -115,6 +139,7 @@ function App() {
               {t.aboutPrinciples.map((item, i) => (
                 <AccordionItem
                   key={i}
+                  id={i}
                   title={item.title}
                   content={item.description}
                   isOpen={openIndex === i}


### PR DESCRIPTION
## Summary
- Enhance AccordionItem with ARIA attributes and region roles
- Handle Enter and Space keys for accordion toggling
- Wire unique IDs between headers and panels

## Testing
- `npx eslint src/App.jsx`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c6fcc53dc832aa1114f5e8d3b57a5