### PR TITLE
feat: add alternate language links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,8 @@
   
     <!-- Canonical -->
     <link rel="canonical" href="https://eixo.design/" />
+    <link rel="alternate" hreflang="en" href="https://eixo.design/" />
+    <link rel="alternate" hreflang="pt" href="https://eixo.design/pt/" />
     <script type="module" crossorigin src="/assets/index-6zjHqf7k.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-JKVWD1o_.css">
   </head>

--- a/docs/pt/index.html
+++ b/docs/pt/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -13,14 +13,14 @@
   
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://eixo.design/" />
+    <meta property="og:url" content="https://eixo.design/pt/" />
     <meta property="og:title" content="eixo.design — UX with clarity, intention and systems" />
     <meta property="og:description" content="Clarity, structure, and purpose through intentional UX and systems design." />
     <meta property="og:image" content="https://eixo.design/og-image.png" />
   
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:url" content="https://eixo.design/" />
+    <meta name="twitter:url" content="https://eixo.design/pt/" />
     <meta name="twitter:title" content="eixo.design — UX with clarity, intention and systems" />
     <meta name="twitter:description" content="Clarity, structure, and purpose through intentional UX and systems design." />
     <meta name="twitter:image" content="https://eixo.design/og-image.png" />
@@ -31,13 +31,14 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&family=EB+Garamond:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet" />
   
     <!-- Canonical -->
-    <link rel="canonical" href="https://eixo.design/" />
+    <link rel="canonical" href="https://eixo.design/pt/" />
     <link rel="alternate" hreflang="en" href="https://eixo.design/" />
     <link rel="alternate" hreflang="pt" href="https://eixo.design/pt/" />
+    <script type="module" crossorigin src="/assets/index-6zjHqf7k.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-JKVWD1o_.css">
   </head>
   
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add hreflang alternate links for English and Portuguese
- provide Portuguese static HTML build for `/pt/`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c6ff52450832abb2c3959e99219b8