### PR TITLE
Preload Google Fonts stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
     <!-- Preload Fonts (optional for performance) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&family=EB+Garamond:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet" />
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&family=EB+Garamond:ital,wght@0,400;0,600;1,400&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'" />
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&family=EB+Garamond:ital,wght@0,400;0,600;1,400&display=swap"></noscript>
   
     <!-- Canonical -->
     <link rel="canonical" href="https://eixo.design/" />

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,6 @@
 /* ----------------------------------------------
    Imports, Fonts & Global Reset
 ---------------------------------------------- */
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&family=EB+Garamond:ital,wght@0,400;0,600;1,400&display=swap');
 
 *,
 *::before,


### PR DESCRIPTION
## Summary
- Preload Google Fonts stylesheet with swap behavior to minimize layout shifts
- Remove redundant CSS `@import` for fonts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c700fbdf4832a879f9ded08db4501