### PR TITLE
feat: add sticky nav menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,13 @@ import logo from './assets/images/eixo-logo-white.png';
 import icon from './assets/images/eixo-icon-white.png';
 import { content, offerings } from './content';
 
+const navItems = [
+  { id: 'about', label: { en: 'Who we are', pt: 'Quem somos' } },
+  { id: 'methodology', label: { en: 'How we work', pt: 'Como trabalhamos' } },
+  { id: 'offerings', label: { en: 'Offerings', pt: 'O que oferecemos' } },
+  { id: 'contact', label: { en: 'Contact', pt: 'Contato' } }
+];
+
 const AccordionItem = ({ id, title, content, isOpen, onClick }) => {
   const buttonId = `accordion-header-${id}`;
   const panelId = `accordion-panel-${id}`;
@@ -113,6 +120,13 @@ function App() {
 
       <header>
         <img src={logo} alt="Eixo Logo" className="logo" />
+        <nav className="nav-menu">
+          {navItems.map((item) => (
+            <a key={item.id} href={`#${item.id}`}>
+              {item.label[lang]}
+            </a>
+          ))}
+        </nav>
         <div className="lang-switcher">
           <button className={lang === 'en' ? 'active' : ''} onClick={() => setLang('en')}>EN</button>
           <button className={lang === 'pt' ? 'active' : ''} onClick={() => setLang('pt')}>PT</button>
@@ -181,7 +195,7 @@ function App() {
           </div>
         </section>
 
-        <footer className="footer fade-up" ref={sectionRefs.contact}>
+        <footer id="contact" className="footer fade-up" ref={sectionRefs.contact}>
           <p>&copy; {new Date().getFullYear()} eixo.design — All rights reserved.</p>
           <p>
             Crafted with clarity · <a href="mailto:hello@eixo.design">hello@eixo.design</a>

--- a/src/index.css
+++ b/src/index.css
@@ -216,21 +216,44 @@ section {
 }
 
 /* ----------------------------------------------
-   Header Styles
+   Header & Navigation Styles
 ---------------------------------------------- */
 header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--color-bg);
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
   flex-wrap: wrap;
+  padding: 1rem var(--gutter);
 }
 
 .logo {
   height: 32px;
   object-fit: contain;
-  margin-left: var(--gutter);
   padding: 0;
+}
+
+.nav-menu {
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.nav-menu a {
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: var(--size-label);
+  letter-spacing: 0.05em;
+  transition: color 0.2s ease;
+}
+
+.nav-menu a:hover {
+  color: var(--color-accent);
 }
 
 .lang-switcher {
@@ -600,15 +623,20 @@ header {
 }
 
 @media (max-width: 768px) {
-  header { 
-    flex-direction: column; 
-    align-items: flex-start; 
-    gap: 1rem; 
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .nav-menu {
+    width: 100%;
+    justify-content: center;
+    margin: 0.5rem 0;
   }
   .lang-switcher { align-self: flex-end; }
-  .cta-button { 
-    padding: 0.6rem 1.2rem; 
-    font-size: 0.95rem; 
+  .cta-button {
+    padding: 0.6rem 1.2rem;
+    font-size: 0.95rem;
   }
   .about p,
   .offering-sub,
@@ -634,6 +662,12 @@ header {
       height: 100vh;
     }
   
+    .nav-menu {
+      width: 100%;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
     .lang-switcher {
       order: -1;
       justify-content: center;


### PR DESCRIPTION
## Summary
- add multilingual navigation menu between logo and language switcher
- style header as sticky top bar with responsive nav links

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7407b0f4832a868cbcd3df85feab