### PR TITLE
feat: add sticky nav menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,13 @@ import logo from './assets/images/eixo-logo-white.png';
 import icon from './assets/images/eixo-icon-white.png';
 import { content, offerings } from './content';
 
+const navItems = [
+  { id: 'about', label: { en: 'Who we are', pt: 'Quem somos' } },
+  { id: 'methodology', label: { en: 'How we work', pt: 'Como trabalhamos' } },
+  { id: 'offerings', label: { en: 'Offerings', pt: 'O que oferecemos' } },
+  { id: 'contact', label: { en: 'Contact', pt: 'Contato' } }
+];
+
 const AccordionItem = ({ id, title, content, isOpen, onClick }) => {
   const buttonId = `accordion-header-${id}`;
   const panelId = `accordion-panel-${id}`;
@@ -113,6 +120,18 @@ function App() {
 
       <header>
         <img src={logo} alt="Eixo Logo" className="logo" />
+        <nav
+          className="nav-menu"
+          aria-label={lang === 'en' ? 'Main navigation' : 'Navegação principal'}
+        >
+          <ul>
+            {navItems.map((item) => (
+              <li key={item.id}>
+                <a href={`#${item.id}`}>{item.label[lang]}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
         <div className="lang-switcher">
           <button className={lang === 'en' ? 'active' : ''} onClick={() => setLang('en')}>EN</button>
           <button className={lang === 'pt' ? 'active' : ''} onClick={() => setLang('pt')}>PT</button>
@@ -181,7 +200,7 @@ function App() {
           </div>
         </section>
 
-        <footer className="footer fade-up" ref={sectionRefs.contact}>
+        <footer id="contact" className="footer fade-up" ref={sectionRefs.contact}>
           <p>&copy; {new Date().getFullYear()} eixo.design — All rights reserved.</p>
           <p>
             Crafted with clarity · <a href="mailto:hello@eixo.design">hello@eixo.design</a>

--- a/src/index.css
+++ b/src/index.css
@@ -194,11 +194,10 @@ h3 {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  padding: var(--gutter);
   box-sizing: border-box;
   position: relative;
   text-align: center;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 section {
@@ -216,21 +215,50 @@ section {
 }
 
 /* ----------------------------------------------
-   Header Styles
+   Header & Navigation Styles
 ---------------------------------------------- */
 header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--color-bg);
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
   flex-wrap: wrap;
+  padding: 1rem var(--gutter);
 }
 
 .logo {
   height: 32px;
   object-fit: contain;
-  margin-left: var(--gutter);
   padding: 0;
+}
+
+.nav-menu {
+  flex: 1;
+}
+
+.nav-menu ul {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-menu a {
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: var(--size-label);
+  letter-spacing: 0.05em;
+  transition: color 0.2s ease;
+}
+
+.nav-menu a:hover {
+  color: var(--color-accent);
 }
 
 .lang-switcher {
@@ -600,77 +628,90 @@ header {
 }
 
 @media (max-width: 768px) {
-  header { 
-    flex-direction: column; 
-    align-items: flex-start; 
-    gap: 1rem; 
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
   }
-  .lang-switcher { align-self: flex-end; }
-  .cta-button { 
-    padding: 0.6rem 1.2rem; 
-    font-size: 0.95rem; 
+  .nav-menu ul {
+    width: 100%;
+    justify-content: center;
+    margin: 0.5rem 0;
+  }
+  .lang-switcher {
+    align-self: flex-end;
+  }
+  .cta-button {
+    padding: 0.6rem 1.2rem;
+    font-size: 0.95rem;
   }
   .about p,
   .offering-sub,
-  .offering-card li { 
-    font-size: 1rem; 
+  .offering-card li {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 767px) {
+  /* Detailed mobile adjustments */
+  header {
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 1rem;
+    padding-top: 1.5rem;
   }
 
-  @media (max-width: 767px) {
-    /* Detailed mobile adjustments */
-    header {
-      flex-direction: column;
-      align-items: center;
-      justify-content: flex-start;
-      gap: 1rem;
-      padding-top: 1.5rem;
-    }
+  section {
+    height: auto;
+  }
 
-    section {
-      height: auto;
-    }
+  #hero {
+    height: 100vh;
+  }
 
-    #hero {
-      height: 100vh;
-    }
-  
-    .lang-switcher {
-      order: -1;
-      justify-content: center;
-      width: 100%;
-      gap: 0.5rem;
-    }
-  
-    .logo {
-      height: clamp(48px, 10vw, 80px);
-      margin: 0 auto;
-      display: block;
-      position: static;
-    }
-  
-    .hero-x {
-      display: none !important;
-    }
-  
-    .hero-text {
-      margin-top: 1rem;
-    }
-  
-    body {
-      display: flex;
-      flex-direction: column;
-      min-height: 100vh;
-    }
-  
-    #root {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-    }
-  
-    .footer {
-      margin-top: auto;
-    }
+  .nav-menu ul {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+  .lang-switcher {
+    order: -1;
+    justify-content: center;
+    width: 100%;
+    gap: 0.5rem;
+  }
+
+  .logo {
+    height: clamp(48px, 10vw, 80px);
+    margin: 0 auto;
+    display: block;
+    position: static;
+  }
+
+  .hero-x {
+    display: none !important;
+  }
+
+  .hero-text {
+    margin-top: 1rem;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  #root {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .footer {
+    margin-top: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure header sticks by stripping padding and overflow from root wrapper
- keep navigation bar styled between logo and language switcher
- use semantic list navigation with responsive adjustments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7407b0f4832a868cbcd3df85feab