### PR TITLE
Improve mobile navigation with responsive menu toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,6 +51,7 @@ function App() {
   const [lang, setLang] = useState('en');
   const t = content[lang];
   const [openIndex, setOpenIndex] = useState(null);
+  const [menuOpen, setMenuOpen] = useState(false);
   const sectionRefs = {
     hero: useRef(null),
     methodology: useRef(null),
@@ -120,14 +121,30 @@ function App() {
 
       <header>
         <img src={logo} alt="Eixo Logo" className="logo" />
+        <button
+          className="menu-toggle"
+          aria-label={
+            lang === 'en'
+              ? menuOpen
+                ? 'Close navigation'
+                : 'Open navigation'
+              : menuOpen
+                ? 'Fechar navegação'
+                : 'Abrir navegação'
+          }
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          {menuOpen ? '\u2715' : '\u2630'}
+        </button>
         <nav
-          className="nav-menu"
+          className={`nav-menu ${menuOpen ? 'open' : ''}`}
           aria-label={lang === 'en' ? 'Main navigation' : 'Navegação principal'}
         >
           <ul>
             {navItems.map((item) => (
               <li key={item.id}>
-                <a href={`#${item.id}`}>{item.label[lang]}</a>
+                <a href={`#${item.id}`} onClick={() => setMenuOpen(false)}>{item.label[lang]}</a>
               </li>
             ))}
           </ul>

--- a/src/index.css
+++ b/src/index.css
@@ -266,6 +266,16 @@ header {
   color: var(--color-accent);
 }
 
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--color-text);
+  color: var(--color-text);
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
 .lang-switcher {
   display: flex;
   gap: 0.5rem;
@@ -665,6 +675,23 @@ header {
     justify-content: flex-start;
     gap: 1rem;
     padding-top: 1.5rem;
+    position: relative;
+  }
+
+  .menu-toggle {
+    display: block;
+    position: absolute;
+    top: 1rem;
+    right: var(--gutter);
+  }
+
+  .nav-menu {
+    display: none;
+    width: 100%;
+  }
+
+  .nav-menu.open {
+    display: block;
   }
 
   section {
@@ -677,7 +704,7 @@ header {
   .nav-menu ul {
     width: 100%;
     justify-content: center;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 0.75rem;
   }
   .lang-switcher {


### PR DESCRIPTION
## Summary
- add hamburger menu button that toggles navigation links on small screens
- hide desktop nav by default on narrow viewports and show vertical menu when opened

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/App.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cbb574a40832a9acf09e254bb5071