### PR TITLE
Fix footer spacing and make logo clickable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -120,7 +120,9 @@ function App() {
       <div className="trail-layer" id="trail-layer"></div>
 
       <header>
-        <img src={logo} alt="Eixo Logo" className="logo" />
+        <a href="#hero">
+          <img src={logo} alt="Eixo Logo" className="logo" />
+        </a>
         <button
           className="menu-toggle"
           aria-label={

--- a/src/index.css
+++ b/src/index.css
@@ -611,6 +611,8 @@ header {
   color: var(--color-subtle);
   font-family: var(--font-sans);
   border-top: 1px solid var(--color-border);
+  scroll-snap-align: end;
+  scroll-snap-stop: always;
 }
 
 .footer a {


### PR DESCRIPTION
## Summary
- Link header logo to hero section
- Snap footer to end of scroll container to avoid empty space

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ce1f71890832a99579f4ae642619a