### PR TITLE
feat: add scroll back button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,6 +52,7 @@ function App() {
   const t = content[lang];
   const [openIndex, setOpenIndex] = useState(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [showScrollTop, setShowScrollTop] = useState(false);
   const sectionRefs = {
     hero: useRef(null),
     methodology: useRef(null),
@@ -90,6 +91,14 @@ function App() {
     };
     window.addEventListener('mousemove', handleMouseMove);
     return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, []);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 300);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
   useEffect(() => {
@@ -226,6 +235,13 @@ function App() {
           </p>
         </footer>
       </main>
+      <button
+        className={`scroll-top ${showScrollTop ? 'visible' : ''}`}
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        aria-label={lang === 'en' ? 'Back to top' : 'Voltar ao topo'}
+      >
+        ↑
+      </button>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -601,6 +601,31 @@ header {
 }
 
 /* ----------------------------------------------
+   Scroll-to-Top Button Styles
+---------------------------------------------- */
+.scroll-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: var(--color-cta-bg);
+  color: var(--color-cta-text);
+  border: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  box-shadow: 0 6px 20px rgba(255, 255, 255, 0.1);
+  z-index: 100;
+}
+
+.scroll-top.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ----------------------------------------------
    Footer Styles
 ---------------------------------------------- */
 .footer {


### PR DESCRIPTION
## Summary
- add scroll-to-top button with smooth scrolling
- style scroll button using existing theme colors

## Testing
- `npm run build`
- `npx eslint src && echo "Lint passed"`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b22f600832a8fa1386979fcf876